### PR TITLE
Add option 'Use only selected features' to DXF export

### DIFF
--- a/python/PyQt6/core/auto_additions/qgsdxfexport.py
+++ b/python/PyQt6/core/auto_additions/qgsdxfexport.py
@@ -1,5 +1,6 @@
 # The following has been generated automatically from src/core/dxf/qgsdxfexport.h
 QgsDxfExport.FlagNoMText = QgsDxfExport.Flag.FlagNoMText
+QgsDxfExport.FlagOnlySelectedFeatures = QgsDxfExport.Flag.FlagOnlySelectedFeatures
 QgsDxfExport.Flags = lambda flags=0: QgsDxfExport.Flag(flags)
 # monkey patching scoped based enum
 QgsDxfExport.ExportResult.Success.__doc__ = "Successful export"

--- a/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -56,6 +56,7 @@ unique value.
     enum Flag /BaseType=IntEnum/
     {
       FlagNoMText,
+      FlagOnlySelectedFeatures,
     };
     typedef QFlags<QgsDxfExport::Flag> Flags;
 

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -56,6 +56,7 @@ unique value.
     enum Flag
     {
       FlagNoMText,
+      FlagOnlySelectedFeatures,
     };
     typedef QFlags<QgsDxfExport::Flag> Flags;
 

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -69,6 +69,7 @@ void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
   std::unique_ptr<QgsProcessingParameterExtent> extentParam = std::make_unique<QgsProcessingParameterExtent>( QStringLiteral( "EXTENT" ), QObject::tr( "Extent" ), QVariant(), true );
   extentParam->setHelp( QObject::tr( "Limit exported features to those with geometries intersecting the provided extent" ) );
   addParameter( extentParam.release() );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SELECTED_FEATURES_ONLY" ), QObject::tr( "Use only selected features" ), false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT elements" ),  true ) );
@@ -108,6 +109,7 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
   const double symbologyScale = parameterAsDouble( parameters, QStringLiteral( "SYMBOLOGY_SCALE" ), context );
   const QString encoding = parameterAsEnumString( parameters, QStringLiteral( "ENCODING" ), context );
   const QgsCoordinateReferenceSystem crs = parameterAsCrs( parameters, QStringLiteral( "CRS" ), context );
+  const bool selectedFeaturesOnly = parameterAsBool( parameters, QStringLiteral( "SELECTED_FEATURES_ONLY" ), context );
   const bool useLayerTitle = parameterAsBool( parameters, QStringLiteral( "USE_LAYER_TITLE" ), context );
   const bool useMText = parameterAsBool( parameters, QStringLiteral( "MTEXT" ), context );
   const bool force2D = parameterAsBool( parameters, QStringLiteral( "FORCE_2D" ), context );
@@ -138,6 +140,8 @@ QVariantMap QgsDxfExportAlgorithm::processAlgorithm( const QVariantMap &paramete
   QgsDxfExport::Flags flags = QgsDxfExport::Flags();
   if ( !useMText )
     flags = flags | QgsDxfExport::FlagNoMText;
+  if ( selectedFeaturesOnly )
+    flags = flags | QgsDxfExport::FlagOnlySelectedFeatures;
   dxfExport.setFlags( flags );
 
   QFile dxfFile( outputFile );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6859,6 +6859,8 @@ void QgisApp::dxfExport()
     QgsDxfExport::Flags flags = QgsDxfExport::Flags();
     if ( !d.useMText() )
       flags = flags | QgsDxfExport::FlagNoMText;
+    if ( d.selectedFeaturesOnly() )
+      flags = flags | QgsDxfExport::FlagOnlySelectedFeatures;
     dxfExport.setFlags( flags );
 
     if ( auto *lMapCanvas = mapCanvas() )

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -567,6 +567,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
     mScaleWidget->setScale( 1.0 / oldScale );
   mLayerTitleAsName->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfLayerTitleAsName" ), settings.value( QStringLiteral( "qgis/lastDxfLayerTitleAsName" ), "false" ).toString() ) != QLatin1String( "false" ) );
   mMapExtentCheckBox->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfMapRectangle" ), settings.value( QStringLiteral( "qgis/lastDxfMapRectangle" ), "false" ).toString() ) != QLatin1String( "false" ) );
+  mSelectedFeaturesOnly->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSelectedFeaturesOnly" ), settings.value( QStringLiteral( "qgis/lastDxfSelectedFeaturesOnly" ), "false" ).toString() ) != QLatin1String( "false" ) );
   mMTextCheckBox->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfUseMText" ), settings.value( QStringLiteral( "qgis/lastDxfUseMText" ), "true" ).toString() ) != QLatin1String( "false" ) );
   mForce2d->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfForce2d" ), settings.value( QStringLiteral( "qgis/lastDxfForce2d" ), "false" ).toString() ) != QLatin1String( "false" ) );
 
@@ -697,6 +698,11 @@ bool QgsDxfExportDialog::exportMapExtent() const
   return mMapExtentCheckBox->isChecked();
 }
 
+bool QgsDxfExportDialog::selectedFeaturesOnly() const
+{
+  return mSelectedFeaturesOnly->isChecked();
+}
+
 bool QgsDxfExportDialog::layerTitleAsName() const
 {
   return mLayerTitleAsName->isChecked();
@@ -720,6 +726,7 @@ void QgsDxfExportDialog::saveSettings()
   settings.setValue( QStringLiteral( "qgis/lastDxfSymbologyMode" ), mSymbologyModeComboBox->currentIndex() );
   settings.setValue( QStringLiteral( "qgis/lastSymbologyExportScale" ), mScaleWidget->scale() != 0 ? 1.0 / mScaleWidget->scale() : 0 );
   settings.setValue( QStringLiteral( "qgis/lastDxfMapRectangle" ), mMapExtentCheckBox->isChecked() );
+  settings.setValue( QStringLiteral( "qgis/lastDxfSelectedFeaturesOnly" ), mSelectedFeaturesOnly->isChecked() );
   settings.setValue( QStringLiteral( "qgis/lastDxfLayerTitleAsName" ), mLayerTitleAsName->isChecked() );
   settings.setValue( QStringLiteral( "qgis/lastDxfEncoding" ), mEncoding->currentText() );
   settings.setValue( QStringLiteral( "qgis/lastDxfCrs" ), QString::number( mCRS.srsid() ) );
@@ -730,6 +737,7 @@ void QgsDxfExportDialog::saveSettings()
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastSymbologyExportScale" ), mScaleWidget->scale() != 0 ? 1.0 / mScaleWidget->scale() : 0 );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfLayerTitleAsName" ), mLayerTitleAsName->isChecked() );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfMapRectangle" ), mMapExtentCheckBox->isChecked() );
+  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSelectedFeaturesOnly" ), mSelectedFeaturesOnly->isChecked() );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), mEncoding->currentText() );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastVisibilityPreset" ), mVisibilityPresets->currentText() );
   QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfCrs" ), QString::number( mCRS.srsid() ) );

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -100,6 +100,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     Qgis::FeatureSymbologyExport symbologyMode() const;
     QString saveFile() const;
     bool exportMapExtent() const;
+    bool selectedFeaturesOnly() const;
     bool layerTitleAsName() const;
     bool force2d() const;
     bool useMText() const;

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -258,7 +258,7 @@ QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QStrin
       const QgsRectangle extentRect = mMapSettings.mapToLayerCoordinates( vl, mExtent );
       request.setFilterRect( extentRect );
     }
-    QgsFeatureIterator featureIt = vl->getFeatures( request );
+    QgsFeatureIterator featureIt = ( mFlags & FlagOnlySelectedFeatures ) ? vl->getSelectedFeatures( request ) : vl->getFeatures( request );
     QgsFeature feature;
     if ( featureIt.nextFeature( feature ) )
     {
@@ -720,6 +720,10 @@ void QgsDxfExport::writeEntities()
     QgsCoordinateTransform extentTransform = ct;
     extentTransform.setBallparkTransformsAreAppropriate( true );
     request.setFilterRect( extentTransform.transformBoundingBox( mMapSettings.extent(), Qgis::TransformDirection::Reverse ) );
+    if ( mFlags & FlagOnlySelectedFeatures )
+    {
+      request.setFilterFids( job->selectedFeatureIds );
+    }
 
     QgsFeatureIterator featureIt = job->featureSource.getFeatures( request );
 
@@ -881,6 +885,10 @@ void QgsDxfExport::writeEntitiesSymbolLevels( DxfLayerJob *job )
   {
     QgsDebugError( QStringLiteral( "QgsDxfExport::writeEntitiesSymbolLevels(): extent reprojection failed" ) );
     return;
+  }
+  if ( mFlags & FlagOnlySelectedFeatures )
+  {
+    req.setFilterFids( job->selectedFeatureIds );
   }
 
   QgsFeatureIterator fit = job->featureSource.getFeatures( req );

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -104,6 +104,7 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
     enum Flag SIP_ENUM_BASETYPE( IntFlag )
     {
       FlagNoMText = 1 << 1, //!< Export text as TEXT elements. If not set, text will be exported as MTEXT elements.
+      FlagOnlySelectedFeatures = 1 << 2, //!< Use only selected features for the export.
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -47,8 +47,8 @@ struct DxfLayerJob
       {
         styleOverride.setOverrideStyle( layerStyleOverride );
       }
-
       fields = vl->fields();
+      selectedFeatureIds = vl->selectedFeatureIds();
       renderer.reset( vl->renderer()->clone() );
       renderContext.expressionContext().appendScope( QgsExpressionContextUtils::layerScope( vl ) );
 
@@ -94,6 +94,7 @@ struct DxfLayerJob
 
     QgsRenderContext renderContext;
     QgsFields fields;
+    QgsFeatureIds selectedFeatureIds;
     QgsMapLayerStyleOverride styleOverride;
     QgsVectorLayerFeatureSource featureSource;
     std::unique_ptr< QgsFeatureRenderer > renderer;

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -203,6 +203,13 @@
        </property>
       </spacer>
      </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="mSelectedFeaturesOnly">
+       <property name="text">
+        <string>Use only selected features</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="15" column="0" colspan="2">

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -73,6 +73,11 @@ class TestQgsDxfExport : public QObject
     void testTransform();
     void testDataDefinedPoints();
     void testExtent();
+    void testSelectedPoints();
+    void testSelectedLines();
+    void testSelectedPolygons();
+    void testMultipleLayersWithSelection();
+    void testExtentWithSelection();
 
   private:
     QgsVectorLayer *mPointLayer = nullptr;
@@ -1445,6 +1450,274 @@ void TestQgsDxfExport::testExtent()
 
   QString debugInfo;
   QCOMPARE( fileContainsText( file2, "polygons", &debugInfo ), false );
+}
+
+void TestQgsDxfExport::testSelectedPoints()
+{
+  mPointLayer->selectByExpression( QStringLiteral( "Class = 'Jet'" ) );
+  QVERIFY( mPointLayer->selectedFeatureCount() > 0 );
+
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mPointLayer->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPointLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPointLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setFlags( QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file = getTempFileName( "selected_points_dxf_only_selected" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  QVERIFY( !fileContainsText( file, QStringLiteral( "nan.0" ) ) );
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mPointLayer->selectedFeatureCount() );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+
+  // There's a selection, but now we want to export all features
+  d.setFlags( d.flags() & ~QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file2 = getTempFileName( "selected_point_dxf_not_only_selected" );
+  QFile dxfFile2( file2 );
+  QCOMPARE( d.writeToFile( &dxfFile2, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile2.close();
+
+  QVERIFY( !fileContainsText( file2, QStringLiteral( "nan.0" ) ) );
+
+  // reload and compare
+  result = std::make_unique< QgsVectorLayer >( file2, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mPointLayer->featureCount() );
+  QVERIFY( mPointLayer->selectedFeatureCount() > 0 );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+
+  mPointLayer->removeSelection();
+}
+
+void TestQgsDxfExport::testSelectedLines()
+{
+  mLineLayer->selectByExpression( QStringLiteral( "Name = 'Highway'" ) );
+  QVERIFY( mLineLayer->selectedFeatureCount() > 0 );
+
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mLineLayer ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mLineLayer->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mLineLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mLineLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setFlags( QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file = getTempFileName( "selected_lines_dxf_only_selected" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mLineLayer->selectedFeatureCount() );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::LineString );
+
+  // There's a selection, but now we want to export all features
+  d.setFlags( d.flags() & ~QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file2 = getTempFileName( "selected_lines_dxf_not_only_selected" );
+  QFile dxfFile2( file2 );
+  QCOMPARE( d.writeToFile( &dxfFile2, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile2.close();
+
+  // reload and compare
+  result = std::make_unique< QgsVectorLayer >( file2, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mLineLayer->featureCount() );
+  QVERIFY( mLineLayer->selectedFeatureCount() > 0 );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::LineString );
+
+  mLineLayer->removeSelection();
+}
+
+void TestQgsDxfExport::testSelectedPolygons()
+{
+  mPolygonLayer->selectByExpression( QStringLiteral( "Name = 'Lake'" ) );
+  QVERIFY( mPolygonLayer->selectedFeatureCount() > 0 );
+
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPolygonLayer ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mPolygonLayer->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPolygonLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPolygonLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setFlags( QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file = getTempFileName( "selected_polygons_dxf_only_selected" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), 8L );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::LineString );
+
+  // There's a selection, but now we want to export all features
+  d.setFlags( d.flags() & ~QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file2 = getTempFileName( "selected_polygons_dxf_not_only_selected" );
+  QFile dxfFile2( file2 );
+  QCOMPARE( d.writeToFile( &dxfFile2, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile2.close();
+
+  // reload and compare
+  result = std::make_unique< QgsVectorLayer >( file2, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), 12L );
+  QVERIFY( mPolygonLayer->selectedFeatureCount() > 0 );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::LineString );
+
+  mPolygonLayer->removeSelection();
+}
+
+void TestQgsDxfExport::testMultipleLayersWithSelection()
+{
+  mPointLayer->selectByExpression( QStringLiteral( "Class = 'Jet'" ) );
+  QVERIFY( mPointLayer->selectedFeatureCount() > 0 );
+  mLineLayer->selectByExpression( QStringLiteral( "Name = 'Highway'" ) );
+  QVERIFY( mLineLayer->selectedFeatureCount() > 0 );
+
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) << QgsDxfExport::DxfLayer( mLineLayer ) );
+
+  QgsRectangle extent;
+  extent = mPointLayer->extent();
+  extent.combineExtentWith( mLineLayer->extent() );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( extent );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPointLayer << mLineLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPointLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setFlags( QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file = getTempFileName( "sel_points_lines_dxf_only_sel" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  QVERIFY( !fileContainsText( file, QStringLiteral( "nan.0" ) ) );
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file, "dxf" );
+  QVERIFY( result->isValid() );
+  QStringList subLayers = result->dataProvider()->subLayers();
+  QCOMPARE( subLayers.count(), 2 );
+  QStringList subLayer1 = { QStringLiteral( "0" ),
+                            QStringLiteral( "entities" ),
+                            QStringLiteral( "8" ),
+                            QStringLiteral( "Point" )
+                          };
+  QStringList subLayer2 = { QStringLiteral( "0" ),
+                            QStringLiteral( "entities" ),
+                            QStringLiteral( "2" ),
+                            QStringLiteral( "LineString" )
+                          };
+  QVERIFY( subLayers.constFirst().startsWith( subLayer1.join( QgsDataProvider::sublayerSeparator() ) ) );
+  QVERIFY( subLayers.constLast().startsWith( subLayer2.join( QgsDataProvider::sublayerSeparator() ) ) );
+
+  // There's a selection, but now we want to export all features
+  d.setFlags( d.flags() & ~QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file2 = getTempFileName( "sel_points_lines_dxf_not_only_sel" );
+  QFile dxfFile2( file2 );
+  QCOMPARE( d.writeToFile( &dxfFile2, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile2.close();
+
+  // reload and compare
+  result = std::make_unique< QgsVectorLayer >( file2, "dxf" );
+  QVERIFY( result->isValid() );
+  subLayers = result->dataProvider()->subLayers();
+  QCOMPARE( subLayers.count(), 2 );
+  subLayer1 = QStringList{ QStringLiteral( "0" ),
+                           QStringLiteral( "entities" ),
+                           QStringLiteral( "%1" ).arg( mPointLayer->featureCount() ),
+                           QStringLiteral( "Point" )
+                         };
+  subLayer2 = QStringList{ QStringLiteral( "0" ),
+                           QStringLiteral( "entities" ),
+                           QStringLiteral( "%1" ).arg( mLineLayer->featureCount() ),
+                           QStringLiteral( "LineString" )
+                         };
+  QVERIFY( subLayers.constFirst().startsWith( subLayer1.join( QgsDataProvider::sublayerSeparator() ) ) );
+  QVERIFY( subLayers.constLast().startsWith( subLayer2.join( QgsDataProvider::sublayerSeparator() ) ) );
+  QVERIFY( mPointLayer->selectedFeatureCount() > 0 );
+  QVERIFY( mLineLayer->selectedFeatureCount() > 0 );
+
+  mPointLayer->removeSelection();
+  mLineLayer->removeSelection();
+}
+
+void TestQgsDxfExport::testExtentWithSelection()
+{
+  mPointLayer->selectByExpression( QStringLiteral( "Class = 'Jet'" ) );
+  QVERIFY( mPointLayer->selectedFeatureCount() > 0 );
+
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mPointLayer->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPointLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPointLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setExtent( QgsRectangle( -109.0, 25.0, -86.0, 37.0 ) );
+  d.setFlags( QgsDxfExport::FlagOnlySelectedFeatures );
+
+  const QString file = getTempFileName( "point_extent_dxf_with_selection" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), 3L ); // 4 in extent, 8 selected, 17 in total
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+  mPointLayer->removeSelection();
 }
 
 bool TestQgsDxfExport::fileContainsText( const QString &path, const QString &text, QString *debugInfo ) const


### PR DESCRIPTION
Enhance DXF export by adding a handy option to filter selected features for each layer.

This adds to the already existing Extent filter, so that users can apply one these two options, or even both at the same time.

The new parameter has also been exposed in the corresponding Processing algorithm.
