### PR TITLE
[dxf] Allow users to override the layer name to be exported to DXF

### DIFF
--- a/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/PyQt6/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -27,7 +27,7 @@ Exports QGIS layers to the DXF format.
 
     struct DxfLayer
     {
-        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1 );
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() );
 
         QgsVectorLayer *layer() const;
 %Docstring
@@ -65,6 +65,13 @@ Flag if data defined point block symbols should be created. Default is false
 Returns the maximum number of data defined symbol classes for which blocks are created. Returns -1 if there is no such limitation
 
 :return:
+
+.. versionadded:: 3.38
+%End
+
+        QString overriddenName() const;
+%Docstring
+Returns the overridden layer name to be used in the exported DXF.
 
 .. versionadded:: 3.38
 %End

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -27,7 +27,7 @@ Exports QGIS layers to the DXF format.
 
     struct DxfLayer
     {
-        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1 );
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() );
 
         QgsVectorLayer *layer() const;
 %Docstring
@@ -65,6 +65,13 @@ Flag if data defined point block symbols should be created. Default is false
 Returns the maximum number of data defined symbol classes for which blocks are created. Returns -1 if there is no such limitation
 
 :return:
+
+.. versionadded:: 3.38
+%End
+
+        QString overriddenName() const;
+%Docstring
+Returns the overridden layer name to be used in the exported DXF.
 
 .. versionadded:: 3.38
 %End

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -47,7 +47,8 @@ QString QgsDxfExportAlgorithm::groupId() const
 
 QString QgsDxfExportAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "Exports layers to DXF file. For each layer, you can choose a field whose values are used to split features in generated destination layers in the DXF output." );
+  return QObject::tr( "Exports layers to DXF file. For each layer, you can choose a field whose values are used to split features in generated destination layers in the DXF output.\n\n"
+                      "If no field is chosen, you can still override the output layer name by preferring layer title (set in layer properties) or by directly entering a new output layer name in the Configure Layer panel." );
 }
 
 QgsDxfExportAlgorithm *QgsDxfExportAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -48,7 +48,7 @@ QString QgsDxfExportAlgorithm::groupId() const
 QString QgsDxfExportAlgorithm::shortHelpString() const
 {
   return QObject::tr( "Exports layers to DXF file. For each layer, you can choose a field whose values are used to split features in generated destination layers in the DXF output.\n\n"
-                      "If no field is chosen, you can still override the output layer name by preferring layer title (set in layer properties) or by directly entering a new output layer name in the Configure Layer panel." );
+                      "If no field is chosen, you can still override the output layer name by directly entering a new output layer name in the Configure Layer panel or by preferring layer title (set in layer properties) to layer name." );
 }
 
 QgsDxfExportAlgorithm *QgsDxfExportAlgorithm::createInstance() const
@@ -72,7 +72,7 @@ void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( extentParam.release() );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SELECTED_FEATURES_ONLY" ), QObject::tr( "Use only selected features" ), false ) );
   std::unique_ptr<QgsProcessingParameterBoolean> useTitleParam = std::make_unique<QgsProcessingParameterBoolean>( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false );
-  useTitleParam->setHelp( QObject::tr( "If no attribute is chosen, prefer layer title (set in layer properties) to layer name" ) );
+  useTitleParam->setHelp( QObject::tr( "If no attribute is chosen and layer name is not being overridden, prefer layer title (set in layer properties) to layer name" ) );
   addParameter( useTitleParam.release() );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT elements" ),  true ) );

--- a/src/analysis/processing/qgsalgorithmdxfexport.cpp
+++ b/src/analysis/processing/qgsalgorithmdxfexport.cpp
@@ -71,7 +71,9 @@ void QgsDxfExportAlgorithm::initAlgorithm( const QVariantMap & )
   extentParam->setHelp( QObject::tr( "Limit exported features to those with geometries intersecting the provided extent" ) );
   addParameter( extentParam.release() );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "SELECTED_FEATURES_ONLY" ), QObject::tr( "Use only selected features" ), false ) );
-  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false ) );
+  std::unique_ptr<QgsProcessingParameterBoolean> useTitleParam = std::make_unique<QgsProcessingParameterBoolean>( QStringLiteral( "USE_LAYER_TITLE" ), QObject::tr( "Use layer title as name" ), false );
+  useTitleParam->setHelp( QObject::tr( "If no attribute is chosen, prefer layer title (set in layer properties) to layer name" ) );
+  addParameter( useTitleParam.release() );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "FORCE_2D" ), QObject::tr( "Force 2D output" ),  false ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "MTEXT" ), QObject::tr( "Export labels as MTEXT elements" ),  true ) );
   addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "DXF" ), QObject::tr( "DXF Files" ) + " (*.dxf *.DXF)" ) );

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -259,8 +259,6 @@ QVariant QgsVectorLayerAndAttributeModel::headerData( int section, Qt::Orientati
 QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role ) const
 {
   QgsVectorLayer *vl = vectorLayer( idx );
-  if ( !vl )
-    return QVariant();
 
   if ( idx.column() == LAYER_COL )
   {
@@ -310,7 +308,7 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
       Q_ASSERT( hasUnchecked );
       return Qt::Unchecked;
     }
-    else if ( role == Qt::DisplayRole && mOverriddenName.contains( vl ) )
+    else if ( role == Qt::DisplayRole && vl && mOverriddenName.contains( vl ) )
     {
       return mOverriddenName[ vl ];
     }
@@ -319,7 +317,7 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
       return QgsLayerTreeModel::data( idx, role );
     }
   }
-  else if ( idx.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
+  else if ( idx.column() == OUTPUT_LAYER_ATTRIBUTE_COL && vl )
   {
     int idx = mAttributeIdx.value( vl, -1 );
     if ( role == Qt::EditRole )
@@ -340,7 +338,7 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
   }
   else if ( idx.column() == ALLOW_DD_SYMBOL_BLOCKS_COL )
   {
-    if ( vl->geometryType() != Qgis::GeometryType::Point )
+    if ( !vl || vl->geometryType() != Qgis::GeometryType::Point )
     {
       return QVariant();
     }
@@ -357,7 +355,7 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
   }
   else if ( idx.column() == MAXIMUM_DD_SYMBOL_BLOCKS_COL )
   {
-    if ( vl->geometryType() != Qgis::GeometryType::Point )
+    if ( !vl || vl->geometryType() != Qgis::GeometryType::Point )
     {
       return QVariant();
     }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -473,7 +473,11 @@ QList< QgsDxfExport::DxfLayer > QgsVectorLayerAndAttributeModel::layers() const
         if ( !layerIdx.contains( vl->id() ) )
         {
           layerIdx.insert( vl->id(), layers.size() );
-          layers << QgsDxfExport::DxfLayer( vl, mAttributeIdx.value( vl, -1 ), mCreateDDBlockInfo.value( vl, true ), mDDBlocksMaxNumberOfClasses.value( vl,  -1 ) );
+          layers << QgsDxfExport::DxfLayer( vl,
+                                            mAttributeIdx.value( vl, -1 ),
+                                            mCreateDDBlockInfo.value( vl, true ),
+                                            mDDBlocksMaxNumberOfClasses.value( vl,  -1 ),
+                                            mOverriddenName.value( vl, QString() ) );
         }
       }
     }
@@ -484,7 +488,11 @@ QList< QgsDxfExport::DxfLayer > QgsVectorLayerAndAttributeModel::layers() const
       if ( !layerIdx.contains( vl->id() ) )
       {
         layerIdx.insert( vl->id(), layers.size() );
-        layers << QgsDxfExport::DxfLayer( vl, mAttributeIdx.value( vl, -1 ), mCreateDDBlockInfo.value( vl, true ), mDDBlocksMaxNumberOfClasses.value( vl,  -1 ) );
+        layers << QgsDxfExport::DxfLayer( vl,
+                                          mAttributeIdx.value( vl, -1 ),
+                                          mCreateDDBlockInfo.value( vl, true ),
+                                          mDDBlocksMaxNumberOfClasses.value( vl,  -1 ),
+                                          mOverriddenName.value( vl, QString() ) );
       }
     }
   }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -826,7 +826,8 @@ void QgsDxfExportDialog::cleanGroup( QgsLayerTreeNode *node )
   {
     if ( QgsLayerTree::isLayer( child ) &&
          ( QgsLayerTree::toLayer( child )->layer()->type() != Qgis::LayerType::Vector ||
-           ! QgsLayerTree::toLayer( child )->layer()->isSpatial() ) )
+           ! QgsLayerTree::toLayer( child )->layer()->isSpatial() ||
+           ! QgsLayerTree::toLayer( child )->layer()->isValid() ) )
     {
       toRemove << child;
       continue;

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -1108,7 +1108,7 @@ void QgsDxfExportDialog::saveSettingsToXML( QDomDocument &doc ) const
   QgsVectorLayerRef vlRef;
   const QgsReadWriteContext rwContext = QgsReadWriteContext();
 
-  for ( const auto dxfLayer : layers() )
+  for ( const auto &dxfLayer : layers() )
   {
     QDomElement layerElement = domDocument.createElement( QStringLiteral( "layer" ) );
     vlRef.setLayer( dxfLayer.layer() );

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -49,7 +49,23 @@ QWidget *FieldSelectorDelegate::createEditor( QWidget *parent, const QStyleOptio
 {
   Q_UNUSED( option )
 
-  if ( index.column() == ALLOW_DD_SYMBOL_BLOCKS_COL )
+  QgsVectorLayer *vl = indexToLayer( index.model(), index );
+  if ( !vl )
+    return nullptr;
+
+  if ( index.column() == LAYER_COL )
+  {
+    QLineEdit *le = new QLineEdit( parent );
+    return le;
+  }
+  else if ( index.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
+  {
+    QgsFieldComboBox *w = new QgsFieldComboBox( parent );
+    w->setLayer( vl );
+    w->setAllowEmptyFieldName( true );
+    return w;
+  }
+  else if ( index.column() == ALLOW_DD_SYMBOL_BLOCKS_COL )
   {
     return nullptr;
   }
@@ -60,44 +76,68 @@ QWidget *FieldSelectorDelegate::createEditor( QWidget *parent, const QStyleOptio
     return le;
   }
 
-  QgsVectorLayer *vl = indexToLayer( index.model(), index );
-  if ( !vl )
-    return nullptr;
-
-  QgsFieldComboBox *w = new QgsFieldComboBox( parent );
-  w->setLayer( vl );
-  w->setAllowEmptyFieldName( true );
-  return w;
+  return nullptr;
 }
 
 void FieldSelectorDelegate::setEditorData( QWidget *editor, const QModelIndex &index ) const
 {
-  if ( index.column() == MAXIMUM_DD_SYMBOL_BLOCKS_COL )
+  QgsVectorLayer *vl = indexToLayer( index.model(), index );
+  if ( !vl )
+    return;
+
+  if ( index.column() == LAYER_COL )
+  {
+    QLineEdit *le = qobject_cast< QLineEdit * >( editor );
+    if ( le )
+    {
+      le->setText( index.data().toString() );
+    }
+  }
+  else if ( index.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
+  {
+    QgsFieldComboBox *fcb = qobject_cast<QgsFieldComboBox *>( editor );
+    if ( !fcb )
+      return;
+
+    int idx = attributeIndex( index.model(), vl );
+    if ( vl->fields().exists( idx ) )
+    {
+      fcb->setField( vl->fields().at( idx ).name() );
+    }
+  }
+  else if ( index.column() == MAXIMUM_DD_SYMBOL_BLOCKS_COL )
   {
     QLineEdit *le = qobject_cast<QLineEdit *>( editor );
     if ( le )
     {
       le->setText( index.data().toString() );
     }
-    return;
   }
-
-  QgsVectorLayer *vl = indexToLayer( index.model(), index );
-  if ( !vl )
-    return;
-
-  QgsFieldComboBox *fcb = qobject_cast<QgsFieldComboBox *>( editor );
-  if ( !fcb )
-    return;
-
-  int idx = attributeIndex( index.model(), vl );
-  if ( vl->fields().exists( idx ) )
-    fcb->setField( vl->fields().at( idx ).name() );
 }
 
 void FieldSelectorDelegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
 {
-  if ( index.column() == MAXIMUM_DD_SYMBOL_BLOCKS_COL )
+  QgsVectorLayer *vl = indexToLayer( index.model(), index );
+  if ( !vl )
+    return;
+
+  if ( index.column() == LAYER_COL )
+  {
+    QLineEdit *le = qobject_cast<QLineEdit *>( editor );
+    if ( le )
+    {
+      model->setData( index, le->text() );
+    }
+  }
+  else if ( index.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
+  {
+    QgsFieldComboBox *fcb = qobject_cast<QgsFieldComboBox *>( editor );
+    if ( !fcb )
+      return;
+
+    model->setData( index, vl->fields().lookupField( fcb->currentField() ) );
+  }
+  else if ( index.column() == MAXIMUM_DD_SYMBOL_BLOCKS_COL )
   {
     QLineEdit *le = qobject_cast<QLineEdit *>( editor );
     if ( le )
@@ -105,16 +145,6 @@ void FieldSelectorDelegate::setModelData( QWidget *editor, QAbstractItemModel *m
       model->setData( index, le->text().toInt() );
     }
   }
-
-  QgsVectorLayer *vl = indexToLayer( index.model(), index );
-  if ( !vl )
-    return;
-
-  QgsFieldComboBox *fcb = qobject_cast<QgsFieldComboBox *>( editor );
-  if ( !fcb )
-    return;
-
-  model->setData( index, vl->fields().lookupField( fcb->currentField() ) );
 }
 
 QgsVectorLayer *FieldSelectorDelegate::indexToLayer( const QAbstractItemModel *model, const QModelIndex &index ) const
@@ -167,7 +197,7 @@ Qt::ItemFlags QgsVectorLayerAndAttributeModel::flags( const QModelIndex &index )
   QgsVectorLayer *vl = vectorLayer( index );
   if ( index.column() == LAYER_COL )
   {
-    return Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
+    return vl ? Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable : Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
   }
   else if ( index.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
   {
@@ -229,6 +259,9 @@ QVariant QgsVectorLayerAndAttributeModel::headerData( int section, Qt::Orientati
 QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role ) const
 {
   QgsVectorLayer *vl = vectorLayer( idx );
+  if ( !vl )
+    return QVariant();
+
   if ( idx.column() == LAYER_COL )
   {
     if ( role == Qt::CheckStateRole )
@@ -277,12 +310,37 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
       Q_ASSERT( hasUnchecked );
       return Qt::Unchecked;
     }
+    else if ( role == Qt::DisplayRole && mOverriddenName.contains( vl ) )
+    {
+      return mOverriddenName[ vl ];
+    }
     else
+    {
       return QgsLayerTreeModel::data( idx, role );
+    }
+  }
+  else if ( idx.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
+  {
+    int idx = mAttributeIdx.value( vl, -1 );
+    if ( role == Qt::EditRole )
+      return idx;
+
+    if ( role == Qt::DisplayRole )
+    {
+      if ( vl->fields().exists( idx ) )
+        return vl->fields().at( idx ).name();
+      else
+        return mOverriddenName.contains( vl ) ? mOverriddenName[ vl ] : vl->name();
+    }
+
+    if ( role == Qt::ToolTipRole )
+    {
+      return tr( "Attribute containing the name of the destination layer in the DXF output." );
+    }
   }
   else if ( idx.column() == ALLOW_DD_SYMBOL_BLOCKS_COL )
   {
-    if ( !vl || vl->geometryType() != Qgis::GeometryType::Point )
+    if ( vl->geometryType() != Qgis::GeometryType::Point )
     {
       return QVariant();
     }
@@ -299,7 +357,7 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
   }
   else if ( idx.column() == MAXIMUM_DD_SYMBOL_BLOCKS_COL )
   {
-    if ( !vl || vl->geometryType() != Qgis::GeometryType::Point )
+    if ( vl->geometryType() != Qgis::GeometryType::Point )
     {
       return QVariant();
     }
@@ -317,65 +375,58 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex &idx, int role
     }
   }
 
-
-  if ( idx.column() == OUTPUT_LAYER_ATTRIBUTE_COL && vl )
-  {
-    int idx = mAttributeIdx.value( vl, -1 );
-    if ( role == Qt::EditRole )
-      return idx;
-
-    if ( role == Qt::DisplayRole )
-    {
-      if ( vl->fields().exists( idx ) )
-        return vl->fields().at( idx ).name();
-      else
-        return vl->name();
-    }
-
-    if ( role == Qt::ToolTipRole )
-    {
-      return tr( "Attribute containing the name of the destination layer in the DXF output." );
-    }
-  }
-
   return QVariant();
 }
 
 bool QgsVectorLayerAndAttributeModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
-  if ( index.column() == LAYER_COL && role == Qt::CheckStateRole )
-  {
-    int i = 0;
-    for ( i = 0; ; i++ )
-    {
-      QModelIndex child = QgsVectorLayerAndAttributeModel::index( i, 0, index );
-      if ( !child.isValid() )
-        break;
-
-      setData( child, value, role );
-    }
-
-    if ( i == 0 )
-    {
-      if ( value.toInt() == Qt::Checked )
-        mCheckedLeafs.insert( index );
-      else if ( value.toInt() == Qt::Unchecked )
-        mCheckedLeafs.remove( index );
-      else
-        Q_ASSERT( "expected checked or unchecked" );
-
-      emit dataChanged( QModelIndex(), index );
-    }
-
-    return true;
-  }
-
   QgsVectorLayer *vl = vectorLayer( index );
-  if ( index.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
+
+  if ( index.column() == LAYER_COL )
+  {
+    if ( role == Qt::CheckStateRole )
+    {
+      int i = 0;
+      for ( i = 0; ; i++ )
+      {
+        QModelIndex child = QgsVectorLayerAndAttributeModel::index( i, 0, index );
+        if ( !child.isValid() )
+          break;
+
+        setData( child, value, role );
+      }
+
+      if ( i == 0 )
+      {
+        if ( value.toInt() == Qt::Checked )
+          mCheckedLeafs.insert( index );
+        else if ( value.toInt() == Qt::Unchecked )
+          mCheckedLeafs.remove( index );
+        else
+          Q_ASSERT( "expected checked or unchecked" );
+
+        emit dataChanged( QModelIndex(), index );
+      }
+
+      return true;
+    }
+    else if ( role == Qt::EditRole )
+    {
+      if ( !value.toString().trimmed().isEmpty() && value.toString() != vl->name() )
+      {
+        mOverriddenName[ vl ] = value.toString();
+      }
+      else
+      {
+        mOverriddenName.remove( vl );
+      }
+      return true;
+    }
+  }
+  else if ( index.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
   {
     if ( role != Qt::EditRole )
       return false;
-
 
     if ( vl )
     {
@@ -383,8 +434,7 @@ bool QgsVectorLayerAndAttributeModel::setData( const QModelIndex &index, const Q
       return true;
     }
   }
-
-  if ( index.column() == ALLOW_DD_SYMBOL_BLOCKS_COL && role == Qt::CheckStateRole )
+  else if ( index.column() == ALLOW_DD_SYMBOL_BLOCKS_COL && role == Qt::CheckStateRole )
   {
     if ( vl )
     {

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -55,7 +55,8 @@ QWidget *FieldSelectorDelegate::createEditor( QWidget *parent, const QStyleOptio
 
   if ( index.column() == LAYER_COL )
   {
-    QLineEdit *le = new QLineEdit( parent );
+    QgsFilterLineEdit *le = new QgsFilterLineEdit( parent, vl->name() );
+
     return le;
   }
   else if ( index.column() == OUTPUT_LAYER_ATTRIBUTE_COL )
@@ -87,7 +88,7 @@ void FieldSelectorDelegate::setEditorData( QWidget *editor, const QModelIndex &i
 
   if ( index.column() == LAYER_COL )
   {
-    QLineEdit *le = qobject_cast< QLineEdit * >( editor );
+    QgsFilterLineEdit *le = qobject_cast< QgsFilterLineEdit * >( editor );
     if ( le )
     {
       le->setText( index.data().toString() );
@@ -123,7 +124,7 @@ void FieldSelectorDelegate::setModelData( QWidget *editor, QAbstractItemModel *m
 
   if ( index.column() == LAYER_COL )
   {
-    QLineEdit *le = qobject_cast<QLineEdit *>( editor );
+    QgsFilterLineEdit *le = qobject_cast<QgsFilterLineEdit *>( editor );
     if ( le )
     {
       model->setData( index, le->text() );

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -81,6 +81,7 @@ class QgsVectorLayerAndAttributeModel : public QgsLayerTreeModel
     QHash<const QgsVectorLayer *, int> mAttributeIdx;
     QHash<const QgsVectorLayer *, bool> mCreateDDBlockInfo;
     QHash<const QgsVectorLayer *, int>  mDDBlocksMaxNumberOfClasses;
+    QHash<const QgsVectorLayer *, QString> mOverriddenName;
     QSet<QModelIndex> mCheckedLeafs;
 
     void applyVisibility( QSet<QString> &visibleLayers, QgsLayerTreeNode *node );

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -2391,10 +2391,18 @@ QStringList QgsDxfExport::encodings()
 QString QgsDxfExport::layerName( QgsVectorLayer *vl ) const
 {
   Q_ASSERT( vl );
-  if ( mLayerTitleAsName && ( !vl->metadata().title().isEmpty() || !vl->serverProperties()->title().isEmpty() ) )
+  if ( !mLayerOverriddenName.value( vl->id(), QString() ).isEmpty() )
+  {
+    return mLayerOverriddenName.value( vl->id() );
+  }
+  else if ( mLayerTitleAsName && ( !vl->metadata().title().isEmpty() || !vl->serverProperties()->title().isEmpty() ) )
+  {
     return !vl->metadata().title().isEmpty() ? vl->metadata().title() : vl->serverProperties()->title();
+  }
   else
-    return mLayerOverriddenName.value( vl->id(), vl->name() );
+  {
+    return vl->name();
+  }
 }
 
 void QgsDxfExport::drawLabel( const QString &layerId, QgsRenderContext &context, pal::LabelPosition *label, const QgsPalLayerSettings &settings )

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -89,16 +89,23 @@ void QgsDxfExport::addLayers( const QList<DxfLayer> &layers )
 {
   mLayerList.clear();
   mLayerNameAttribute.clear();
+  mLayerOverriddenName.clear();
 
   mLayerList.reserve( layers.size() );
   for ( const DxfLayer &dxfLayer : layers )
   {
     mLayerList << dxfLayer.layer();
     if ( dxfLayer.layerOutputAttributeIndex() >= 0 )
+    {
       mLayerNameAttribute.insert( dxfLayer.layer()->id(), dxfLayer.layerOutputAttributeIndex() );
+    }
     if ( dxfLayer.buildDataDefinedBlocks() )
     {
       mLayerDDBlockMaxNumberOfClasses.insert( dxfLayer.layer()->id(), dxfLayer.dataDefinedBlocksMaximumNumberOfClasses() );
+    }
+    if ( dxfLayer.overriddenName() != QString() )
+    {
+      mLayerOverriddenName.insert( dxfLayer.layer()->id(), dxfLayer.overriddenName() );
     }
   }
 }
@@ -776,7 +783,7 @@ void QgsDxfExport::writeEntities()
     while ( featureIt.nextFeature( fet ) )
     {
       mRenderContext.expressionContext().setFeature( fet );
-      QString lName( dxfLayerName( job->splitLayerAttribute.isNull() ? job->layerTitle : fet.attribute( job->splitLayerAttribute ).toString() ) );
+      QString lName( dxfLayerName( job->splitLayerAttribute.isNull() ? job->layerDerivedName : fet.attribute( job->splitLayerAttribute ).toString() ) );
 
       sctx.setFeature( &fet );
 
@@ -903,7 +910,7 @@ void QgsDxfExport::prepareRenderers()
     const QgsFields fields = vl->fields();
     if ( splitLayerAttributeIndex >= 0 && splitLayerAttributeIndex < fields.size() )
       splitLayerAttribute = fields.at( splitLayerAttributeIndex ).name();
-    DxfLayerJob *job = new DxfLayerJob( vl, mMapSettings.layerStyleOverrides().value( vl->id() ), mRenderContext, this, splitLayerAttribute );
+    DxfLayerJob *job = new DxfLayerJob( vl, mMapSettings.layerStyleOverrides().value( vl->id() ), mRenderContext, this, splitLayerAttribute, layerName( vl ) );
     mJobs.append( job );
   }
 }
@@ -2384,9 +2391,10 @@ QStringList QgsDxfExport::encodings()
 QString QgsDxfExport::layerName( QgsVectorLayer *vl ) const
 {
   Q_ASSERT( vl );
-  return mLayerTitleAsName && ( !vl->metadata().title().isEmpty() ||  !vl->serverProperties()->title().isEmpty() )
-         ? ( !vl->metadata().title().isEmpty() ? vl->metadata().title() : vl->serverProperties()->title() )
-         : vl->name();
+  if ( mLayerTitleAsName && ( !vl->metadata().title().isEmpty() || !vl->serverProperties()->title().isEmpty() ) )
+    return !vl->metadata().title().isEmpty() ? vl->metadata().title() : vl->serverProperties()->title();
+  else
+    return mLayerOverriddenName.value( vl->id(), vl->name() );
 }
 
 void QgsDxfExport::drawLabel( const QString &layerId, QgsRenderContext &context, pal::LabelPosition *label, const QgsPalLayerSettings &settings )

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -73,11 +73,12 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
      */
     struct CORE_EXPORT DxfLayer
     {
-        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1 )
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1, bool buildDDBlocks = true, int ddBlocksMaxNumberOfClasses = -1, QString overriddenName = QString() )
           : mLayer( vl )
           , mLayerOutputAttributeIndex( layerOutputAttributeIndex )
           , mBuildDDBlocks( buildDDBlocks )
           , mDDBlocksMaxNumberOfClasses( ddBlocksMaxNumberOfClasses )
+          , mOverriddenName( overriddenName )
         {}
 
         //! Returns the layer
@@ -112,6 +113,12 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
          */
         int dataDefinedBlocksMaximumNumberOfClasses() const { return mDDBlocksMaxNumberOfClasses; }
 
+        /**
+        * \brief Returns the overridden layer name to be used in the exported DXF.
+        * \since QGIS 3.38
+        */
+        QString overriddenName() const { return mOverriddenName; }
+
       private:
         QgsVectorLayer *mLayer = nullptr;
         int mLayerOutputAttributeIndex = -1;
@@ -125,6 +132,11 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
          * \brief Limit for the number of data defined symbol block classes (keep only the most used ones). -1 means no limit
          */
         int mDDBlocksMaxNumberOfClasses = -1;
+
+        /**
+         * \brief Overridden name of the layer to be exported to DXF
+         */
+        QString mOverriddenName = QString();
     };
 
     //! Export flags
@@ -667,6 +679,7 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
     QList<QgsMapLayer *> mLayerList;
     QHash<QString, int> mLayerNameAttribute;
     QHash<QString, int> mLayerDDBlockMaxNumberOfClasses;
+    QHash<QString, QString> mLayerOverriddenName;
     double mFactor = 1.0;
     bool mForce2d = false;
 

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -136,7 +136,7 @@ class CORE_EXPORT QgsDxfExport : public QgsLabelSink
         /**
          * \brief Overridden name of the layer to be exported to DXF
          */
-        QString mOverriddenName = QString();
+        QString mOverriddenName;
     };
 
     //! Export flags

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -105,7 +105,7 @@ struct DxfLayerJob
     QgsLabelSinkProvider *labelProvider = nullptr;
     QgsRuleBasedLabelSinkProvider *ruleBasedLabelProvider = nullptr;
     QString splitLayerAttribute;
-    QString layerDerivedName;  // Obtained from layer title, name or overridden name
+    QString layerDerivedName;  // Obtained from overridden name, title or layer name
     QSet<QString> attributes;
 
   private:

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -33,7 +33,7 @@
  */
 struct DxfLayerJob
 {
-    DxfLayerJob( QgsVectorLayer *vl, const QString &layerStyleOverride, QgsRenderContext &renderContext, QgsDxfExport *dxfExport, const QString &splitLayerAttribute )
+    DxfLayerJob( QgsVectorLayer *vl, const QString &layerStyleOverride, QgsRenderContext &renderContext, QgsDxfExport *dxfExport, const QString &splitLayerAttribute, const QString &layerDerivedName )
       : renderContext( renderContext )
       , styleOverride( vl )
       , featureSource( vl )
@@ -41,8 +41,7 @@ struct DxfLayerJob
       , crs( vl->crs() )
       , layerName( vl->name() )
       , splitLayerAttribute( splitLayerAttribute )
-      , layerTitle( !vl->metadata().title().isEmpty() ? vl->metadata().title()
-                    : vl->serverProperties()->title().isEmpty() ? vl->name() : vl->serverProperties()->title() )
+      , layerDerivedName( layerDerivedName )
     {
       if ( !layerStyleOverride.isNull() )
       {
@@ -106,7 +105,7 @@ struct DxfLayerJob
     QgsLabelSinkProvider *labelProvider = nullptr;
     QgsRuleBasedLabelSinkProvider *ruleBasedLabelProvider = nullptr;
     QString splitLayerAttribute;
-    QString layerTitle;
+    QString layerDerivedName;  // Obtained from layer title, name or overridden name
     QSet<QString> attributes;
 
   private:

--- a/src/core/processing/qgsprocessingparameterdxflayers.cpp
+++ b/src/core/processing/qgsprocessingparameterdxflayers.cpp
@@ -85,7 +85,7 @@ bool QgsProcessingParameterDxfLayers::checkValueIsAcceptable( const QVariant &in
       {
         const QVariantMap layerMap = variantLayer.toMap();
 
-        if ( !layerMap.contains( QStringLiteral( "layer" ) ) && !layerMap.contains( QStringLiteral( "attributeIndex" ) ) )
+        if ( !layerMap.contains( QStringLiteral( "layer" ) ) && !layerMap.contains( QStringLiteral( "attributeIndex" ) ) && !layerMap.contains( QStringLiteral( "overriddenLayerName" ) ) )
           return false;
 
         if ( !context )
@@ -144,8 +144,11 @@ QString QgsProcessingParameterDxfLayers::valueAsPythonString( const QVariant &va
   {
     QStringList layerDefParts;
     layerDefParts << QStringLiteral( "'layer': " ) + QgsProcessingUtils::stringToPythonLiteral( QgsProcessingUtils::normalizeLayerSource( layer.layer()->source() ) );
+
     if ( layer.layerOutputAttributeIndex() >= -1 )
       layerDefParts << QStringLiteral( "'attributeIndex': " ) + QgsProcessingUtils::variantToPythonLiteral( layer.layerOutputAttributeIndex() );
+
+    layerDefParts << QStringLiteral( "'overriddenLayerName': " ) + QgsProcessingUtils::stringToPythonLiteral( layer.overriddenName() );
 
     const QString layerDef = QStringLiteral( "{%1}" ).arg( layerDefParts.join( ',' ) );
     parts << layerDef;
@@ -239,7 +242,11 @@ QgsDxfExport::DxfLayer QgsProcessingParameterDxfLayers::variantMapAsLayer( const
     // bad
   }
 
-  QgsDxfExport::DxfLayer dxfLayer( inputLayer, layerVariantMap[ QStringLiteral( "attributeIndex" ) ].toInt() );
+  QgsDxfExport::DxfLayer dxfLayer( inputLayer,
+                                   layerVariantMap[ QStringLiteral( "attributeIndex" ) ].toInt(),
+                                   false,
+                                   -1,
+                                   layerVariantMap[ QStringLiteral( "overriddenLayerName" ) ].toString() );
   return dxfLayer;
 }
 
@@ -251,5 +258,6 @@ QVariantMap QgsProcessingParameterDxfLayers::layerAsVariantMap( const QgsDxfExpo
 
   vm[ QStringLiteral( "layer" )] = layer.layer()->id();
   vm[ QStringLiteral( "attributeIndex" ) ] = layer.layerOutputAttributeIndex();
+  vm[ QStringLiteral( "overriddenLayerName" ) ] = layer.overriddenName();
   return vm;
 }

--- a/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingdxflayerswidgetwrapper.cpp
@@ -51,14 +51,16 @@ QgsProcessingDxfLayerDetailsWidget::QgsProcessingDxfLayerDetailsWidget( const QV
 
   if ( mLayer->fields().exists( layer.layerOutputAttributeIndex() ) )
     mFieldsComboBox->setField( mLayer->fields().at( layer.layerOutputAttributeIndex() ).name() );
+  mOverriddenName->setText( layer.overriddenName() );
 
   connect( mFieldsComboBox, &QgsFieldComboBox::fieldChanged, this, &QgsPanelWidget::widgetChanged );
+  connect( mOverriddenName, &QLineEdit::textChanged, this, &QgsPanelWidget::widgetChanged );
 }
 
 QVariant QgsProcessingDxfLayerDetailsWidget::value() const
 {
   const int index = mLayer->fields().lookupField( mFieldsComboBox->currentField() );
-  const QgsDxfExport::DxfLayer layer( mLayer, index );
+  const QgsDxfExport::DxfLayer layer( mLayer, index, false, -1, mOverriddenName->text().trimmed() );
   return QgsProcessingParameterDxfLayers::layerAsVariantMap( layer );
 }
 
@@ -104,6 +106,7 @@ QgsProcessingDxfLayersPanelWidget::QgsProcessingDxfLayersPanelWidget(
     QVariantMap vm;
     vm["layer"] = layer->id();
     vm["attributeIndex"] = -1;
+    vm["overriddenLayerName"] = QString();
 
     const QString title = layer->name();
     addOption( vm, title, false );
@@ -166,8 +169,19 @@ QString QgsProcessingDxfLayersPanelWidget::titleForLayer( const QgsDxfExport::Dx
 {
   QString title = layer.layer()->name();
 
+  // if both options are set, the split attribute takes precedence,
+  // so hide overridden message to give users a hint on the result.
   if ( layer.layerOutputAttributeIndex() != -1 )
+  {
     title += tr( " [split attribute: %1]" ).arg( layer.splitLayerAttribute() );
+  }
+  else
+  {
+    if ( !layer.overriddenName().isEmpty() )
+    {
+      title += tr( " [overridden name: %1]" ).arg( layer.overriddenName() );
+    }
+  }
 
   return title;
 }

--- a/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
+++ b/src/ui/processing/qgsprocessingdxflayerdetailswidgetbase.ui
@@ -7,28 +7,21 @@
     <x>0</x>
     <y>0</y>
     <width>393</width>
-    <height>71</height>
+    <height>144</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Attribute</string>
-     </property>
-    </widget>
+   <item row="0" column="1" colspan="2">
+    <widget class="QgsFieldComboBox" name="mFieldsComboBox"/>
    </item>
-   <item row="2" column="2">
+   <item row="3" column="2">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QgsFieldComboBox" name="mFieldsComboBox"/>
-   </item>
-   <item row="1" column="0" colspan="3">
+   <item row="2" column="0" colspan="3">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -40,6 +33,23 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Attribute</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Output layer name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QLineEdit" name="mOverriddenName"/>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -172,7 +172,7 @@
      <item row="0" column="0">
       <widget class="QCheckBox" name="mLayerTitleAsName">
        <property name="toolTip">
-        <string>If no attribute is chosen, prefer layer title (set in layer properties) to layer name.</string>
+        <string>If no attribute is chosen and layer name is not being overridden, prefer layer title (set in layer properties) to layer name.</string>
        </property>
        <property name="text">
         <string>Use layer title as name if set</string>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -171,6 +171,9 @@
      </item>
      <item row="0" column="0">
       <widget class="QCheckBox" name="mLayerTitleAsName">
+       <property name="toolTip">
+        <string>If no attribute is chosen, prefer layer title (set in layer properties) to layer name.</string>
+       </property>
        <property name="text">
         <string>Use layer title as name if set</string>
        </property>

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -1813,8 +1813,8 @@ void TestQgsDxfExport::testOutputLayerNamePrecedence()
 {
   // Test that output layer name precedence is:
   // 1) Attribute (if any)
-  // 2) Layer title (if any)
-  // 3) Overridden name (if any)
+  // 2) Overridden name (if any)
+  // 3) Layer title (if any)
   // 4) Layer name
 
   const QString layerTitle = QStringLiteral( "Point Layer Title" );
@@ -1871,8 +1871,8 @@ void TestQgsDxfExport::testOutputLayerNamePrecedence()
   dxfFile2.close();
 
   QVERIFY( !fileContainsText( file2, QStringLiteral( "nan.0" ) ) );
-  QVERIFY( fileContainsText( file2, layerTitle ) );
-  QVERIFY( !fileContainsText( file2, layerOverriddenName ) );
+  QVERIFY( !fileContainsText( file2, layerTitle ) );
+  QVERIFY( fileContainsText( file2, layerOverriddenName ) );
   QVERIFY( !fileContainsText( file2, mPointLayer->name() ) );
 
   // reload and compare
@@ -1882,20 +1882,20 @@ void TestQgsDxfExport::testOutputLayerNamePrecedence()
   QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
   QgsFeature feature;
   result->getFeatures().nextFeature( feature );
-  QCOMPARE( feature.attribute( "Layer" ), layerTitle );
+  QCOMPARE( feature.attribute( "Layer" ), layerOverriddenName );
   QCOMPARE( result->uniqueValues( 0 ).count(), 1 ); // "Layer" field
 
-  // C) No attribute given, choose no title
-  d.setLayerTitleAsName( false );
+  // C) No attribute given, no override
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer, -1, false, -1 ) ); // this replaces layers
 
-  const QString file3 = getTempFileName( "name_precedence_c_no_attr_no_title_dxf" );
+  const QString file3 = getTempFileName( "name_precedence_c_no_attr_no_override_dxf" );
   QFile dxfFile3( file3 );
   QCOMPARE( d.writeToFile( &dxfFile3, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile3.close();
 
   QVERIFY( !fileContainsText( file3, QStringLiteral( "nan.0" ) ) );
-  QVERIFY( !fileContainsText( file3, layerTitle ) );
-  QVERIFY( fileContainsText( file3, layerOverriddenName ) );
+  QVERIFY( fileContainsText( file3, layerTitle ) );
+  QVERIFY( !fileContainsText( file3, layerOverriddenName ) );
   QVERIFY( !fileContainsText( file3, mPointLayer->name() ) );
 
   // reload and compare
@@ -1904,11 +1904,12 @@ void TestQgsDxfExport::testOutputLayerNamePrecedence()
   QCOMPARE( result->featureCount(), mPointLayer->featureCount() );
   QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
   result->getFeatures().nextFeature( feature );
-  QCOMPARE( feature.attribute( "Layer" ), layerOverriddenName );
+  QCOMPARE( feature.attribute( "Layer" ), layerTitle );
   QCOMPARE( result->uniqueValues( 0 ).count(), 1 ); // "Layer" field
 
   // D) No name options given, use default layer name
   d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) ); // This replaces layers
+  d.setLayerTitleAsName( false );
 
   const QString file4 = getTempFileName( "name_precedence_d_no_anything_dxf" );
   QFile dxfFile4( file4 );

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -1822,7 +1822,7 @@ void TestQgsDxfExport::testOutputLayerNamePrecedence()
 
   // A) All layer name options are set
   QgsDxfExport d;
-  mPointLayer->setTitle( layerTitle );
+  mPointLayer->serverProperties()->setTitle( layerTitle );
   d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer,
                0, // Class attribute, 3 unique values
                false,
@@ -1929,7 +1929,7 @@ void TestQgsDxfExport::testOutputLayerNamePrecedence()
   QCOMPARE( feature.attribute( "Layer" ), mPointLayer->name() );
   QCOMPARE( result->uniqueValues( 0 ).count(), 1 ); // "Layer" field
 
-  mPointLayer->setTitle( QString() ); // Leave the original empty title
+  mPointLayer->serverProperties()->setTitle( QString() ); // Leave the original empty title
 }
 
 bool TestQgsDxfExport::fileContainsText( const QString &path, const QString &text, QString *debugInfo ) const

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -55,6 +55,7 @@ class TestQgsDxfExport : public QObject
     void testPoints();
     void testPointsDataDefinedSizeAngle();
     void testPointsDataDefinedSizeSymbol();
+    void testPointsOverriddenName();
     void testLines();
     void testPolygons();
     void testMultiSurface();
@@ -81,6 +82,7 @@ class TestQgsDxfExport : public QObject
     void testSelectedPolygons();
     void testMultipleLayersWithSelection();
     void testExtentWithSelection();
+    void testOutputLayerNamePrecedence();
 
   private:
     QgsVectorLayer *mPointLayer = nullptr;
@@ -281,6 +283,40 @@ void TestQgsDxfExport::testPointsDataDefinedSizeSymbol()
   QVERIFY( dxfString.contains( QStringLiteral( "symbolLayer0class" ) ) );
   //test a rotation for a referenced block
   QVERIFY( dxfString.contains( QStringLiteral( "50\n5.0" ) ) );
+}
+
+void TestQgsDxfExport::testPointsOverriddenName()
+{
+  QgsDxfExport d;
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer, -1, false, -1, QStringLiteral( "My Point Layer" ) ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mPointLayer->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPointLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPointLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+
+  const QString file = getTempFileName( "point_overridden_name_dxf" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  QVERIFY( !fileContainsText( file, QStringLiteral( "nan.0" ) ) );
+  QVERIFY( !fileContainsText( file, mPointLayer->name() ) ); // "points"
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mPointLayer->featureCount() );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+  QgsFeature feature;
+  result->getFeatures().nextFeature( feature );
+  QCOMPARE( feature.attribute( "Layer" ), QStringLiteral( "My Point Layer" ) );
 }
 
 void TestQgsDxfExport::testLines()
@@ -1771,6 +1807,129 @@ void TestQgsDxfExport::testExtentWithSelection()
   QCOMPARE( result->featureCount(), 3L ); // 4 in extent, 8 selected, 17 in total
   QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
   mPointLayer->removeSelection();
+}
+
+void TestQgsDxfExport::testOutputLayerNamePrecedence()
+{
+  // Test that output layer name precedence is:
+  // 1) Attribute (if any)
+  // 2) Layer title (if any)
+  // 3) Overridden name (if any)
+  // 4) Layer name
+
+  const QString layerTitle = QStringLiteral( "Point Layer Title" );
+  const QString layerOverriddenName = QStringLiteral( "My Point Layer" );
+
+  // A) All layer name options are set
+  QgsDxfExport d;
+  mPointLayer->setTitle( layerTitle );
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer,
+               0, // Class attribute, 3 unique values
+               false,
+               -1,
+               layerOverriddenName ) );
+
+  QgsMapSettings mapSettings;
+  const QSize size( 640, 480 );
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( mPointLayer->extent() );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << mPointLayer );
+  mapSettings.setOutputDpi( 96 );
+  mapSettings.setDestinationCrs( mPointLayer->crs() );
+
+  d.setMapSettings( mapSettings );
+  d.setSymbologyScale( 1000 );
+  d.setLayerTitleAsName( true );
+
+  const QString file = getTempFileName( "name_precedence_a_all_set_dxf" );
+  QFile dxfFile( file );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile.close();
+
+  QVERIFY( !fileContainsText( file, QStringLiteral( "nan.0" ) ) );
+  QVERIFY( !fileContainsText( file, layerTitle ) );
+  QVERIFY( !fileContainsText( file, layerOverriddenName ) );
+  QVERIFY( !fileContainsText( file, mPointLayer->name() ) );
+
+  // reload and compare
+  std::unique_ptr< QgsVectorLayer > result = std::make_unique< QgsVectorLayer >( file, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mPointLayer->featureCount() );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+  QSet<QVariant> values = result->uniqueValues( 0 ); // "Layer" field
+  QCOMPARE( values.count(), 3 );
+  QVERIFY( values.contains( QVariant( "B52" ) ) );
+  QVERIFY( values.contains( QVariant( "Jet" ) ) );
+  QVERIFY( values.contains( QVariant( "Biplane" ) ) );
+
+  // B) No attribute given
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer, -1, false, -1, layerOverriddenName ) ); // this replaces layers
+
+  const QString file2 = getTempFileName( "name_precedence_b_no_attr_dxf" );
+  QFile dxfFile2( file2 );
+  QCOMPARE( d.writeToFile( &dxfFile2, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile2.close();
+
+  QVERIFY( !fileContainsText( file2, QStringLiteral( "nan.0" ) ) );
+  QVERIFY( fileContainsText( file2, layerTitle ) );
+  QVERIFY( !fileContainsText( file2, layerOverriddenName ) );
+  QVERIFY( !fileContainsText( file2, mPointLayer->name() ) );
+
+  // reload and compare
+  result = std::make_unique< QgsVectorLayer >( file2, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mPointLayer->featureCount() );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+  QgsFeature feature;
+  result->getFeatures().nextFeature( feature );
+  QCOMPARE( feature.attribute( "Layer" ), layerTitle );
+  QCOMPARE( result->uniqueValues( 0 ).count(), 1 ); // "Layer" field
+
+  // C) No attribute given, choose no title
+  d.setLayerTitleAsName( false );
+
+  const QString file3 = getTempFileName( "name_precedence_c_no_attr_no_title_dxf" );
+  QFile dxfFile3( file3 );
+  QCOMPARE( d.writeToFile( &dxfFile3, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile3.close();
+
+  QVERIFY( !fileContainsText( file3, QStringLiteral( "nan.0" ) ) );
+  QVERIFY( !fileContainsText( file3, layerTitle ) );
+  QVERIFY( fileContainsText( file3, layerOverriddenName ) );
+  QVERIFY( !fileContainsText( file3, mPointLayer->name() ) );
+
+  // reload and compare
+  result = std::make_unique< QgsVectorLayer >( file3, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mPointLayer->featureCount() );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+  result->getFeatures().nextFeature( feature );
+  QCOMPARE( feature.attribute( "Layer" ), layerOverriddenName );
+  QCOMPARE( result->uniqueValues( 0 ).count(), 1 ); // "Layer" field
+
+  // D) No name options given, use default layer name
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) ); // This replaces layers
+
+  const QString file4 = getTempFileName( "name_precedence_d_no_anything_dxf" );
+  QFile dxfFile4( file4 );
+  QCOMPARE( d.writeToFile( &dxfFile4, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
+  dxfFile4.close();
+
+  QVERIFY( !fileContainsText( file4, QStringLiteral( "nan.0" ) ) );
+  QVERIFY( !fileContainsText( file4, layerTitle ) );
+  QVERIFY( !fileContainsText( file4, layerOverriddenName ) );
+  QVERIFY( fileContainsText( file4, mPointLayer->name() ) );
+
+  // reload and compare
+  result = std::make_unique< QgsVectorLayer >( file4, "dxf" );
+  QVERIFY( result->isValid() );
+  QCOMPARE( result->featureCount(), mPointLayer->featureCount() );
+  QCOMPARE( result->wkbType(), Qgis::WkbType::Point );
+  result->getFeatures().nextFeature( feature );
+  QCOMPARE( feature.attribute( "Layer" ), mPointLayer->name() );
+  QCOMPARE( result->uniqueValues( 0 ).count(), 1 ); // "Layer" field
+
+  mPointLayer->setTitle( QString() ); // Leave the original empty title
 }
 
 bool TestQgsDxfExport::fileContainsText( const QString &path, const QString &text, QString *debugInfo ) const

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -9988,6 +9988,7 @@ void TestProcessingGui::testDxfLayersWrapper()
   QVariantMap layerMap;
   layerMap["layer"] = "PointLayer";
   layerMap["attributeIndex"] = -1;
+  layerMap["overriddenLayerName"] = QString();
   layerList.append( layerMap );
 
   QVERIFY( definition.checkValueIsAcceptable( layerList, &context ) );
@@ -9998,7 +9999,7 @@ void TestProcessingGui::testDxfLayersWrapper()
 
   QVERIFY( definition.checkValueIsAcceptable( value, &context ) );
   QString valueAsPythonString = definition.valueAsPythonString( value, context );
-  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1}]" ).arg( vectorLayer->source() ) );
+  QCOMPARE( valueAsPythonString, QStringLiteral( "[{'layer': '%1','attributeIndex': -1,'overriddenLayerName': ''}]" ).arg( vectorLayer->source() ) );
 }
 
 void TestProcessingGui::testAlignRasterLayersWrapper()


### PR DESCRIPTION
This PR makes it possible to override the output name of individual layers exported in the DXF Export dialog.

The corresponding processing algorithm's GUI and parameter were also updated accordingly.

Tests were added for:
   + Output layer name precedence for the exported DXF: 1) attribute, 2) layer title, 3) overridden layer name, 4) layer name.
   + Processing `qgsprocessingparameterdxflayers` parameter and DXF layer's widget wrapper.

Screencast App dialog

https://github.com/gacarrillor/QGIS/assets/652785/fbb3443e-24fe-45b6-b735-43d3b4abdea5

Screencast Processing dialog

https://github.com/gacarrillor/QGIS/assets/652785/d94e3ce4-a289-4888-88c5-4557259dc3e2

UX hints for the users:

![DXFExport_algs_help](https://github.com/gacarrillor/QGIS/assets/652785/b1598aae-f43b-4d06-b0b0-ccf7836e0f7d)
![DXFExport_tooltip](https://github.com/gacarrillor/QGIS/assets/652785/f2ab1349-ee97-4d42-a3f4-f70955220b47)


