### PR TITLE
Main and layout Elevation Profile's layer order (another approach)

### DIFF
--- a/src/app/elevation/qgselevationprofilewidget.cpp
+++ b/src/app/elevation/qgselevationprofilewidget.cpp
@@ -637,7 +637,6 @@ void QgsElevationProfileWidget::updateCanvasLayers()
       layers << layer;
   }
 
-  std::reverse( layers.begin(), layers.end() );
   mCanvas->setLayers( layers );
   scheduleUpdate();
 }

--- a/src/core/layout/qgslayoutitemelevationprofile.cpp
+++ b/src/core/layout/qgslayoutitemelevationprofile.cpp
@@ -688,6 +688,7 @@ void QgsLayoutItemElevationProfile::paint( QPainter *painter, const QStyleOption
           if ( QgsAbstractProfileSource *source = layer->profileSource() )
             sources.append( source );
         }
+        std::reverse( sources.begin(), sources.end() ); // sources are rendered from bottom to top
 
         QgsProfilePlotRenderer renderer( sources, profileRequest() );
         std::unique_ptr<QgsLineSymbol> rendererSubSectionsSymbol( subsectionsSymbol() ? subsectionsSymbol()->clone() : nullptr );
@@ -743,6 +744,7 @@ void QgsLayoutItemElevationProfile::paint( QPainter *painter, const QStyleOption
           if ( QgsAbstractProfileSource *source = layer->profileSource() )
             sources.append( source );
         }
+        std::reverse( sources.begin(), sources.end() ); // sources are rendered from bottom to top
 
         QgsProfilePlotRenderer renderer( sources, profileRequest() );
         std::unique_ptr<QgsLineSymbol> rendererSubSectionsSymbol( subsectionsSymbol() ? subsectionsSymbol()->clone() : nullptr );
@@ -1000,6 +1002,7 @@ void QgsLayoutItemElevationProfile::recreateCachedImageInBackground()
     if ( QgsAbstractProfileSource *source = layer->profileSource() )
       sources.append( source );
   }
+  std::reverse( sources.begin(), sources.end() ); // sources are rendered from bottom to top
 
   mRenderJob = std::make_unique< QgsProfilePlotRenderer >( sources, profileRequest() );
   std::unique_ptr<QgsLineSymbol> rendererSubSectionsSymbol( subsectionsSymbol() ? subsectionsSymbol()->clone() : nullptr );

--- a/src/gui/elevation/qgselevationprofilecanvas.cpp
+++ b/src/gui/elevation/qgselevationprofilecanvas.cpp
@@ -889,6 +889,7 @@ void QgsElevationProfileCanvas::refresh()
     if ( QgsAbstractProfileSource *source = layer->profileSource() )
       sources.append( source );
   }
+  std::reverse( sources.begin(), sources.end() ); // sources are rendered from bottom to top
 
   mCurrentJob = new QgsProfilePlotRenderer( sources, request );
   connect( mCurrentJob, &QgsProfilePlotRenderer::generationFinished, this, &QgsElevationProfileCanvas::generationFinished );

--- a/src/gui/layout/qgslayoutelevationprofilewidget.cpp
+++ b/src/gui/layout/qgslayoutelevationprofilewidget.cpp
@@ -657,8 +657,6 @@ void QgsLayoutElevationProfileWidget::copySettingsFromProfileCanvas( QgsElevatio
   }
 
   QList<QgsMapLayer *> canvasLayers = canvas->layers();
-  // canvas layers are in opposite direction to what the layout item requires
-  std::reverse( canvasLayers.begin(), canvasLayers.end() );
   mProfile->setLayers( canvasLayers );
   const QList<QgsLayerTreeLayer *> layers = mLayerTree->findLayers();
   for ( QgsLayerTreeLayer *layer : layers )

--- a/src/gui/layout/qgslayoutelevationprofilewidget.h
+++ b/src/gui/layout/qgslayoutelevationprofilewidget.h
@@ -80,6 +80,8 @@ class GUI_EXPORT QgsLayoutElevationProfileWidget : public QgsLayoutItemBaseWidge
     QgsLayerTreeRegistryBridge *mLayerTreeBridge = nullptr;
     QgsElevationProfileLayerTreeView *mLayerTreeView = nullptr;
     QMenu *mCopyFromDockMenu = nullptr;
+
+    friend class TestQgsLayoutGui;
 };
 
 #endif //QGSLAYOUTELEVATIONPROFILEWIDGET_H

--- a/tests/src/gui/testqgslayoutgui.cpp
+++ b/tests/src/gui/testqgslayoutgui.cpp
@@ -22,6 +22,11 @@
 #include "qgslayoutitemmap.h"
 #include "qgslayoutmodel.h"
 #include "qgslayoutitemcombobox.h"
+#include "qgslayoutelevationprofilewidget.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayerelevationproperties.h"
+#include "qgselevationprofilecanvas.h"
+#include "qgslayertree.h"
 
 #include <QApplication>
 #include <QMainWindow>
@@ -39,6 +44,7 @@ class TestQgsLayoutGui : public QObject
 
     void itemTypeComboBox();
     void testProxyCrash();
+    void testElevationProfileWidget();
 
   private:
 };
@@ -235,6 +241,57 @@ void TestQgsLayoutGui::testProxyCrash()
   delete layout;
 }
 
+void TestQgsLayoutGui::testElevationProfileWidget()
+{
+  QgsProject project;
+  QgsLayout layout( &project );
+  QgsVectorLayer *vl1 = new QgsVectorLayer( QStringLiteral( "Point?field=intarray:int[]&field=strarray:string[]&field=intf:int" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+  qobject_cast< QgsVectorLayerElevationProperties * >( vl1->elevationProperties() )->setZOffset( 5 );
+  QgsVectorLayer *vl2 = new QgsVectorLayer( QStringLiteral( "Point?field=intarray:int[]&field=strarray:string[]&field=intf:int" ), QStringLiteral( "vl2" ), QStringLiteral( "memory" ) );
+  qobject_cast< QgsVectorLayerElevationProperties * >( vl2->elevationProperties() )->setZOffset( 5 );
+  QgsVectorLayer *vl3 = new QgsVectorLayer( QStringLiteral( "Point?field=intarray:int[]&field=strarray:string[]&field=intf:int" ), QStringLiteral( "vl3" ), QStringLiteral( "memory" ) );
+  qobject_cast< QgsVectorLayerElevationProperties * >( vl3->elevationProperties() )->setZOffset( 5 );
+  project.addMapLayers( { vl1, vl2, vl3 } );
+
+  QgsLayoutItemElevationProfile profile( &layout );
+  // layers will be rendered from v1->vl3 from bottom to top
+  profile.setLayers( { vl1, vl2, vl3 } );
+  QgsLayoutElevationProfileWidget widget( &profile );
+
+  QCOMPARE( widget.mLayerTree->children().size(), 3 );
+  // in widget's layer tree the layers should be in order v1->vl3 from bottom to top
+  QCOMPARE( qobject_cast< QgsLayerTreeLayer * >( widget.mLayerTree->children().at( 0 ) )->layer()->name(), QStringLiteral( "vl1" ) );
+  QVERIFY( widget.mLayerTree->children().at( 0 )->isItemVisibilityCheckedRecursive() );
+  QCOMPARE( qobject_cast< QgsLayerTreeLayer * >( widget.mLayerTree->children().at( 1 ) )->layer()->name(), QStringLiteral( "vl2" ) );
+  QVERIFY( widget.mLayerTree->children().at( 1 )->isItemVisibilityCheckedRecursive() );
+  QCOMPARE( qobject_cast< QgsLayerTreeLayer * >( widget.mLayerTree->children().at( 2 ) )->layer()->name(), QStringLiteral( "vl3" ) );
+  QVERIFY( widget.mLayerTree->children().at( 2 )->isItemVisibilityCheckedRecursive() );
+
+  // uncheck a layer
+  widget.mLayerTree->children().at( 1 )->setItemVisibilityChecked( false );
+  QCOMPARE( profile.layers().size(), 2 );
+  // layers should be in order of rendering, ie vl1 before vl3 as vl3 is rendered on top
+  QCOMPARE( profile.layers().at( 0 )->name(), QStringLiteral( "vl1" ) );
+  QCOMPARE( profile.layers().at( 1 )->name(), QStringLiteral( "vl3" ) );
+
+  QgsElevationProfileCanvas canvas;
+  // layers will be rendered from v1->vl3 from bottom to top
+  canvas.setLayers( { vl1, vl2, vl3 } );
+
+  widget.copySettingsFromProfileCanvas( &canvas );
+  QCOMPARE( profile.layers().size(), 3 );
+  // layers should be in order of rendering, ie vl1 before vl3 as vl3 is rendered on top
+  QCOMPARE( profile.layers().at( 0 )->name(), QStringLiteral( "vl1" ) );
+  QCOMPARE( profile.layers().at( 1 )->name(), QStringLiteral( "vl2" ) );
+  QCOMPARE( profile.layers().at( 2 )->name(), QStringLiteral( "vl3" ) );
+
+  canvas.setLayers( { vl3, vl2, vl1 } );
+  widget.copySettingsFromProfileCanvas( &canvas );
+  QCOMPARE( profile.layers().size(), 3 );
+  QCOMPARE( profile.layers().at( 0 )->name(), QStringLiteral( "vl3" ) );
+  QCOMPARE( profile.layers().at( 1 )->name(), QStringLiteral( "vl2" ) );
+  QCOMPARE( profile.layers().at( 2 )->name(), QStringLiteral( "vl1" ) );
+}
 
 QTEST_MAIN( TestQgsLayoutGui )
 #include "testqgslayoutgui.moc"


### PR DESCRIPTION
Make sure canvas, layout item profile, and layer tree layers can be called in the same order, and only reverse the order right before sending the corresponding sources to the QgsProfilePlotRenderer.

This fixes the QGIS issue with the layout profile rendering order (# 61064).